### PR TITLE
Link no longer working got (301 Moved Permanently)

### DIFF
--- a/prepare-files.sh
+++ b/prepare-files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 KERNEL_VERSION="4.10"
-LINK="https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz"
+LINK="https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-${KERNEL_VERSION}.tar.xz"
 
 TBL_32="/tmp/linux-${KERNEL_VERSION}/arch/x86/entry/syscalls/syscall_32.tbl"
 


### PR DESCRIPTION
it moved permanently to https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-$KERNEL_VERSION.tar.xz

consider change the link or use `wget` instead if the new link moved again
